### PR TITLE
Elasticsearch-dsl refactor, unit test, config update

### DIFF
--- a/fmatch/requirements.txt
+++ b/fmatch/requirements.txt
@@ -8,8 +8,8 @@ coverage==7.4.0
 dill==0.3.7
 docutils==0.20.1
 elastic-transport==8.11.0
-elasticsearch==8.11.1
-elasticsearch7==7.13.0
+elasticsearch==7.13.0
+elasticsearch-dsl==7.4.1
 idna==3.6
 importlib-metadata==7.0.1
 iniconfig==2.0.0
@@ -21,7 +21,7 @@ mccabe==0.7.0
 mdurl==0.1.2
 more-itertools==10.2.0
 nh3==0.2.15
-numpy==1.24.0
+numpy==1.26.3
 packaging==23.2
 pandas==2.1.4
 pip-name==1.0.2

--- a/fmatch/test_fmatch.py
+++ b/fmatch/test_fmatch.py
@@ -11,7 +11,6 @@ from matcher import Matcher
 
 match = Matcher(index="perf_scale_ci")
 res=match.get_metadata_by_uuid("b4afc724-f175-44d1-81ff-a8255fea034f",'perf_scale_ci')
-print(res)
 
 meta = {}
 meta["masterNodesType"] = "m6a.xlarge"
@@ -28,15 +27,12 @@ meta["benchmark"] = "cluster-density-v2"
 # meta['fips'] = "false"
 
 uuids = match.get_uuid_by_metadata(meta)
-print(len(uuids))
 if len(uuids) == 0:
     print("No UUID present for given metadata")
     sys.exit()
 runs = match.match_kube_burner(uuids)
 
-# print(len(runs))
 ids = match.filter_runs(runs, runs)
-print(len(ids))
 podl_metrics = {
     "name": "podReadyLatency",
     "metricName": "podLatencyQuantilesMeasurement",
@@ -55,9 +51,7 @@ kapi_metrics = {
 kapi_cpu = match.get_agg_metric_query(ids, "ripsaw-kube-burner*", metrics=kapi_metrics)
 podl_df = match.convert_to_df(
     podl, columns=['uuid', 'timestamp', 'quantileName', 'P99'])
-print(podl_df)
 kapi_cpu_df = match.convert_to_df(kapi_cpu)
-print(kapi_cpu_df)
 merge_df = pd.merge(kapi_cpu_df, podl_df, on="uuid")
 match.save_results(merge_df, "merged.csv", [
                    "uuid", "timestamp_x", "cpu_avg", "P99"])

--- a/fmatch/test_fmatch.py
+++ b/fmatch/test_fmatch.py
@@ -3,10 +3,8 @@ test_fmatch
 """
 
 import sys
-
-import pandas as pd
-
 # pylint: disable=import-error
+import pandas as pd
 
 # pylint: disable=import-error
 from matcher import Matcher

--- a/fmatch/test_fmatch.py
+++ b/fmatch/test_fmatch.py
@@ -1,53 +1,68 @@
 """
 test_fmatch
 """
+
 import sys
-# pylint: disable=import-error
+
 import pandas as pd
+
+# pylint: disable=import-error
+
 # pylint: disable=import-error
 from matcher import Matcher
 
-match = Matcher(index='perf_scale_ci')
+match = Matcher(index="perf_scale_ci")
+res=match.get_metadata_by_uuid("b4afc724-f175-44d1-81ff-a8255fea034f",'perf_scale_ci')
+print(res)
 
 meta = {}
-meta['benchmark'] = "cluster-density-v2"
-meta['masterNodesType'] = "m6a.xlarge"
-meta['workerNodesType'] = "m6a.xlarge"
-meta['platform'] = "AWS"
-meta['masterNodesCount'] = 3
-meta['workerNodesCount'] = 24
-meta['jobStatus'] = "success"
-meta['ocpVersion'] = '4.15'
-meta['networkType'] = "OVNKubernetes"
-meta['encrypted'] = "true"
-meta['ipsec'] = "false"
-meta['fips'] = "false"
+meta["masterNodesType"] = "m6a.xlarge"
+meta["workerNodesType"] = "m6a.xlarge"
+meta["platform"] = "AWS"
+meta["masterNodesCount"] = 3
+meta["workerNodesCount"] = 24
+meta["jobStatus"] = "success"
+meta["ocpVersion"] = "4.15"
+meta["networkType"] = "OVNKubernetes"
+meta["benchmark"] = "cluster-density-v2"
+# meta['encrypted'] = "true"
+# meta['ipsec'] = "false"
+# meta['fips'] = "false"
 
 uuids = match.get_uuid_by_metadata(meta)
+print(len(uuids))
 if len(uuids) == 0:
     print("No UUID present for given metadata")
     sys.exit()
 runs = match.match_kube_burner(uuids)
+
+# print(len(runs))
 ids = match.filter_runs(runs, runs)
-podl = match.burner_results("", ids, "ripsaw-kube-burner*")
-
-kapi_cpu = match.burner_cpu_results(
-    ids, "openshift-kube-apiserver", "ripsaw-kube-burner*")
-ovn_cpu = match.burner_cpu_results(
-    ids, "openshift-ovn-kubernetes", "ripsaw-kube-burner*")
-etcd_cpu = match.burner_cpu_results(
-    ids, "openshift-etcd", "ripsaw-kube-burner*")
-ovn_mem = match.burner_mem_results(
-    ids, "openshift-ovn-kubernetes", "ripsaw-kube-burner*")
-
+print(len(ids))
+podl_metrics = {
+    "name": "podReadyLatency",
+    "metricName": "podLatencyQuantilesMeasurement",
+    "quantileName": "Ready",
+    "metric_of_interest": "P99",
+    "not": {"jobConfig.name": "garbage-collection"},
+}
+podl = match.getResults("", ids, "ripsaw-kube-burner*",metrics=podl_metrics)
+kapi_metrics = {
+    "name": "apiserverCPU",
+    "metricName": "containerCPU",
+    "labels.namespace": "openshift-kube-apiserver",
+    "metric_of_interest": "value",
+    "agg": {"value": "cpu", "agg_type": "avg"},
+}
+kapi_cpu = match.get_agg_metric_query(ids, "ripsaw-kube-burner*", metrics=kapi_metrics)
 podl_df = match.convert_to_df(
     podl, columns=['uuid', 'timestamp', 'quantileName', 'P99'])
+print(podl_df)
 kapi_cpu_df = match.convert_to_df(kapi_cpu)
+print(kapi_cpu_df)
 merge_df = pd.merge(kapi_cpu_df, podl_df, on="uuid")
 match.save_results(merge_df, "merged.csv", [
                    "uuid", "timestamp_x", "cpu_avg", "P99"])
-match.save_results(kapi_cpu_df, "CPUavg24.csv")
-match.save_results(podl_df, "podlatency24.csv")
 
 df = pd.read_csv("merged.csv")
 ls = df["uuid"].to_list()

--- a/fmatch/tests/test_matcher.py
+++ b/fmatch/tests/test_matcher.py
@@ -143,38 +143,6 @@ def test_filter_runs(matcher_instance):
     assert result == expected
 
 
-# def test_parse_agg_results(matcher_instance):
-#     # Mocked data for the Elasticsearch DSL query response
-#     response_data = {
-#         "aggregations": {
-#             "time": {
-#                 "buckets": [
-#                     {"key": "uuid1", "time": {"value_as_string": "2022-01-01T00:00:00"}},
-#                     {"key": "uuid2", "time": {"value_as_string": "2022-01-01T01:00:00"}},
-#                 ]
-#             },
-#             "uuid": {
-#                 "buckets": [
-#                     {"key": "uuid1", "your_agg_field": {"value": 10}},
-#                     {"key": "uuid2", "your_agg_field": {"value": 20}},
-#                 ]
-#             },
-#         }
-#     }
-
-#     # Call the parse_agg_results method
-#     parsed_results = matcher_instance.parse_agg_results(response_data, "your_agg_field", "avg")
-
-#     # Define the expected result
-#     expected = [
-#         {"uuid": "uuid1", "timestamp": "2022-01-01T00:00:00", "your_agg_field_avg": 10},
-#         {"uuid": "uuid2", "timestamp": "2022-01-01T01:00:00", "your_agg_field_avg": 20},
-#     ]
-
-#     # Assert the result matches the expected value
-#     assert parsed_results == expected
-
-
 def test_getResults(matcher_instance):
     test_uuid = "uuid1"
     test_uuids = ["uuid1", "uuid2"]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup file for fmatch package
 from setuptools import setup, find_packages
 
 
-VERSION = '0.0.4'
+VERSION = '0.0.5'
 DESCRIPTION = 'Common package for matching runs with provided metadata'
 # pylint: disable= line-too-long
 LONG_DESCRIPTION = "A package that allows to match metadata and get runs and create csv files with queried metrics"
@@ -19,7 +19,7 @@ setup(
     long_description_content_type="text/x-rst",
     long_description=LONG_DESCRIPTION,
     packages=find_packages(),
-    install_requires=['elasticsearch7==7.13.0', 'elasticsearch', 'pyyaml','pandas'],
+    install_requires=['elasticsearch==7.13.0', 'elasticsearch-dsl', 'pyyaml','pandas'],
     keywords=['python', 'matching', 'red hat', 'perf-scale', 'matcher', 'orion'],
     classifiers=[
         "Development Status :: 1 - Planning",


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I have integrated elasticsearch-dsl library such that there is better code readabilty and more abstraction to our queries. One change included in the following iteration is regarding config files which are sent by orion.
```
metrics : 
    - name:  podReadyLatency
      metricName: podLatencyQuantilesMeasurement
      quantileName: Ready
      metric_of_interest: P99
      not: 
      - jobConfig.name: "garbage-collection"
```
the above config when translated gives a `"not" list`, at the moment this list is a list of dictionaries, with each dictionary having only one `key:value` pair. The change implemented now takes in the not list as a dictionary with multiple `key:value` pairs
```
metrics : 
    - name:  podReadyLatency
      metricName: podLatencyQuantilesMeasurement
      quantileName: Ready
      metric_of_interest: P99
      not: 
          jobConfig.name: "garbage-collection"
```
<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #17 
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Unit tests coverage of 100%
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
