### PR TITLE
uuids to include buildUrls

### DIFF
--- a/fmatch/matcher.py
+++ b/fmatch/matcher.py
@@ -92,8 +92,9 @@ class Matcher:
         s = Search(using=self.es, index=index).query(query).extra(size=self.search_size)
         result = self.query_index(index, s)
         hits = result.hits.hits
-        uuids = [hit.to_dict()["_source"]["uuid"] for hit in hits]
-        return uuids
+        uuids_docs = [{ "uuid":hit.to_dict()["_source"]["uuid"],
+                        "buildUrl":hit.to_dict()["_source"]["buildUrl"]} for hit in hits]
+        return uuids_docs
 
     def match_kube_burner(self, uuids):
         """match kube burner runs

--- a/fmatch/tests/test_matcher.py
+++ b/fmatch/tests/test_matcher.py
@@ -59,7 +59,10 @@ def test_query_index(matcher_instance):
 def test_get_uuid_by_metadata(matcher_instance):
     matcher_instance.es.search = lambda *args, **kwargs: {
         "hits": {
-            "hits": [{"_source": {"uuid": "uuid1"}}, {"_source": {"uuid": "uuid2"}}]
+            "hits": [{"_source": {"uuid": "uuid1",
+                                  "buildUrl":"buildUrl1"}}, 
+                    {"_source": {"uuid": "uuid2",
+                                  "buildUrl":"buildUrl1"}}]
         }
     }
     meta = {
@@ -67,7 +70,10 @@ def test_get_uuid_by_metadata(matcher_instance):
         "ocpVersion": "4.15",
     }
     result = matcher_instance.get_uuid_by_metadata(meta)
-    expected = ["uuid1", "uuid2"]
+    expected = [{"uuid": "uuid1",
+                "buildUrl":"buildUrl1"},
+                {"uuid": "uuid2",
+                "buildUrl":"buildUrl1"}]
     assert result == expected
 
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
adding buildUrls to `get_uuid_by_metadata()`. This change is in order to add buildUrls to cmd-mode of orion.

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
