### PR TITLE
remove not from must clause

### DIFF
--- a/fmatch/matcher.py
+++ b/fmatch/matcher.py
@@ -103,8 +103,7 @@ class Matcher:
                 else Q("match", **{field: value})
             )
             for field, value in meta.items()
-            if field not in "ocpVersion"
-            if field not in "ocpMajorVersion"
+            if field not in ["ocpVersion", "ocpMajorVersion", "not"]
         ]
 
         for field, value in meta.get("not", {}).items():


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I forgot to filter out "not" from the must clause.

With this metadata:
```json
{
  "platform": "AWS",
  "clusterType": "self-managed",
  "masterNodesType": "m6a.xlarge",
  "masterNodesCount": "3",
  "workerNodesType": "m6a.xlarge",
  "workerNodesCount": "6",
  "benchmark.keyword": "node-density",
  "ocpVersion": "4.18",
  "networkType": "OVNKubernetes",
  "jobType": "periodic",
  "not": {
    "uuid.keyword": "f30d388a-b024-4786-bc0e-2d4ef9351017"
  }
}

```
Now it produces a right query


```shell
{'query': {'bool': {'must': [{'match': {'platform': 'AWS'}}, {'match': {'clusterType': 'self-managed'}}, {'match': {'masterNodesType': 'm6a.xlarge'}}, {'match': {'masterNodesCount': '3'}}, {'match': {'workerNodesType': 'm6a.xlarge'}}, {'match': {'workerNodesCount': '6'}}, {'match': {'benchmark.keyword': 'node-density'}}, {'match': {'networkType': 'OVNKubernetes'}}, {'match': {'jobType': 'periodic'}}], 'must_not': [{'match': {'uuid.keyword': 'f30d388a-b024-4786-bc0e-2d4ef9351017'}}], 'filter': [{'wildcard': {'ocpVersion': '4.18*'}}]}}, 'sort': [{'timestamp': {'order': 'desc'}}], 'size': 5}
```