### PR TITLE
Update langchain-core to >=1.3.0 and require Python >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "py-commons"
 version = "0.3.0"
 description = "Common Python libraries for Red Hat tools and automation"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [
     {name = "Red Hat Performance and Scale", email = "jtaleric@redhat.com"}
@@ -17,8 +17,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -29,7 +27,7 @@ classifiers = [
 dependencies = [
     "jira>=3.0.0",
     "openai>=1.0.0",
-    "langchain-core>=0.1.0,<0.3.0",
+    "langchain-core>=1.3.0",
     "httpx>=0.27.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,11 @@ setup(
     long_description=LONG_DESCRIPTION,
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=[
         "jira>=3.0.0",
         "openai>=1.0.0",
-        "langchain-core>=0.1.0,<0.3.0",
+        "langchain-core>=1.3.0",
         "httpx>=0.27.0",
     ],
     extras_require={
@@ -45,8 +45,6 @@ setup(
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

BugZooka requires langchain_core >= 1.3.0. Set py-commons to that minimum and upgraded python to 3.10 to be compatible with new langchain_core version.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Passed usual inference module tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Python version requirement to 3.10 (previously 3.8).
  * Upgraded langchain-core dependency to version 1.3.0 or higher.
  * Dropped support for Python 3.8 and 3.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->